### PR TITLE
Rename default branch from `master` to `main` (#32)

### DIFF
--- a/.github/upgrades/scenarios/dotnet-version-upgrade/scenario-instructions.md
+++ b/.github/upgrades/scenarios/dotnet-version-upgrade/scenario-instructions.md
@@ -49,7 +49,7 @@ These projects share `Engine` / `ChessTrainer.Common` / `ChessTrainer.Data` with
 - **EF migrations**: live in `ChessTrainerApp` (`MigrationsAssembly("MjrChess.Trainer")`). Not moved in this scenario.
 
 ## Source Control
-- **Source Branch**: `master`
+- **Source Branch**: `main`
 - **Working Branch**: `upgrade-dotnet-10`
 - **Commit Strategy**: After Each Task
 - **Branch Sync**: Auto (Merge)


### PR DESCRIPTION
Closes #32.

## What's in this PR

- `.github/upgrades/scenarios/dotnet-version-upgrade/scenario-instructions.md` — flipped the historical `**Source Branch**: master` line to `main`. This is the **only** in-repo doc reference to `master` that we own.

## What's intentionally NOT changed

Four files contain `master` only inside URLs that point to **other** GitHub repos. Those projects' default branches are still `master`, so rewriting the links would break them:

- `.gitignore` — link to `github/gitignore`
- `stylecop.json` — schema URL on `DotNetAnalyzers/StyleCopAnalyzers`
- `src/ChessTrainerApp/Pages/About.razor` — link to `official-stockfish/Stockfish`
- `src/ChessTrainerApp/BlazorExtensions/ExpandedRouteView.cs` — historical attribution links to `aspnet/AspNetCore`

## What also wasn't needed

- **CI workflows** — none exist yet (tracked in #36); when they're added in that issue they'll target `main` directly.
- **`CONTRIBUTING.md`** — doesn't exist.
- **Infra** (`infrastructure/ChessTrainerRG/`) — no branch references.
- **`README.md` / `.github/copilot-instructions.md`** — no `master` references.

## Owner action still required (cannot be done in a PR)

After merge, please complete the GitHub-side rename:

1. Repo Settings → Branches → rename `master` → `main`. GitHub will auto-redirect refs, retarget open PRs, and update the default branch.
2. Update the Copilot CLI project's `default_branch` setting (currently `master`) to `main`.
3. Share the contributor migration snippet from the issue:
   ```sh
   git branch -m master main
   git fetch origin
   git branch -u origin/main main
   git remote set-head origin -a
   ```

## Build / test

Doc-only change — no build or test run required (verified via repo-wide `grep -i master` that only external URLs remain).