### PR TITLE
Add UI theming system and dark mode support

### DIFF
--- a/src/ChessTrainerApp/Components/ChessPieceComponent.razor
+++ b/src/ChessTrainerApp/Components/ChessPieceComponent.razor
@@ -12,7 +12,7 @@
     [Parameter]
     public int Rank { get; set; }
 
-    public string Class => $"piece {ChessFormatter.FileToString(File)}{ChessFormatter.RankToString(Rank)}";
+    public string Class => $"piece piece--{(ChessFormatter.IsPieceWhite(PieceType) ? "white" : "black")} {ChessFormatter.FileToString(File)}{ChessFormatter.RankToString(Rank)}";
 
     string ImageSource => $"{SpriteSource}#{SvgView}";
 

--- a/src/ChessTrainerApp/Pages/_Host.cshtml
+++ b/src/ChessTrainerApp/Pages/_Host.cshtml
@@ -18,6 +18,18 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chess Trainer</title>
+    @* Apply the saved theme before any content renders to avoid a flash of the
+       wrong theme. Defaults to light when no preference has been stored. *@
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('ct-theme');
+                document.documentElement.setAttribute('data-theme', stored === 'dark' ? 'dark' : 'light');
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
     <link href="app.bundle.css" rel="stylesheet" />
     @if (javaScriptSnippet is not null)
     {

--- a/src/ChessTrainerApp/Shared/NavBar.razor
+++ b/src/ChessTrainerApp/Shared/NavBar.razor
@@ -12,6 +12,12 @@
         </section>
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
             @ChildContent
+            <button class="material-icons mdc-top-app-bar__action-item mdc-icon-button"
+                    aria-label="@ThemeToggleLabel"
+                    title="@ThemeToggleLabel"
+                    @onclick="ToggleTheme">
+                @ThemeToggleIcon
+            </button>
             <SignIn></SignIn>
         </section>
     </div>
@@ -38,6 +44,34 @@
 @code {
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    private bool isDarkTheme;
+
+    private string ThemeToggleIcon => isDarkTheme ? "light_mode" : "dark_mode";
+
+    private string ThemeToggleLabel => isDarkTheme ? "Switch to light theme" : "Switch to dark theme";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var theme = await JSRuntime.InvokeAsync<string>("getTheme");
+            var darkActive = theme == "dark";
+            if (darkActive != isDarkTheme)
+            {
+                isDarkTheme = darkActive;
+                StateHasChanged();
+            }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    async Task ToggleTheme()
+    {
+        var theme = await JSRuntime.InvokeAsync<string>("toggleTheme");
+        isDarkTheme = theme == "dark";
+    }
 
     async Task ToggleMainMenuDrawer()
     {

--- a/src/ChessTrainerApp/app/_dark-theme.scss
+++ b/src/ChessTrainerApp/app/_dark-theme.scss
@@ -1,0 +1,180 @@
+// Dark "skin" for Material Components Web.
+//
+// MDC 4.0 bakes its light theme colors into the compiled CSS, so we can't
+// re-theme it by changing Sass variables at runtime. Instead, when
+// `data-theme="dark"` is set on <html>, we restyle the MDC component surfaces
+// we actually use, pulling colors from the --ct-* tokens in _tokens.scss.
+
+[data-theme="dark"] {
+    background-color: var(--ct-background);
+    color: var(--ct-on-background);
+
+    body,
+    html {
+        background-color: var(--ct-background);
+        color: var(--ct-on-background);
+    }
+
+    // Top app bar
+    .mdc-top-app-bar {
+        background-color: var(--ct-app-bar-bg);
+        color: var(--ct-app-bar-on);
+    }
+
+    .mdc-top-app-bar__title a,
+    .mdc-top-app-bar__title.link {
+        color: var(--ct-app-bar-on);
+    }
+
+    .mdc-top-app-bar .mdc-icon-button,
+    .mdc-top-app-bar .mdc-button {
+        color: var(--ct-app-bar-on);
+    }
+
+    // Navigation drawer
+    .mdc-drawer {
+        background-color: var(--ct-drawer-bg);
+        border-color: var(--ct-border);
+        color: var(--ct-drawer-on);
+    }
+
+    .mdc-drawer .mdc-list-item {
+        color: var(--ct-drawer-on);
+    }
+
+    .mdc-drawer .mdc-list-item__graphic {
+        color: var(--ct-text-secondary);
+    }
+
+    .mdc-drawer .mdc-list-item--activated {
+        color: var(--ct-color-primary);
+    }
+
+    .mdc-drawer .mdc-list-item--activated .mdc-list-item__graphic {
+        color: var(--ct-color-primary);
+    }
+
+    // Cards
+    .mdc-card {
+        background-color: var(--ct-surface);
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-card .mdc-list-item__text,
+    .mdc-card .mdc-icon-button {
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-card .mdc-list-item__secondary-text {
+        color: var(--ct-text-secondary);
+    }
+
+    // Generic typography / text
+    .mdc-typography--subtitle2,
+    .mdc-typography--subtitle2 svg {
+        color: var(--ct-text-secondary);
+    }
+
+    // Lists
+    .mdc-list-item__primary-text {
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-list-item__secondary-text {
+        color: var(--ct-text-secondary);
+    }
+
+    // Text fields (filled + outlined)
+    .mdc-text-field {
+        background-color: rgba(255, 255, 255, 0.04);
+    }
+
+    .mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__input {
+        color: var(--ct-on-surface);
+        caret-color: var(--ct-color-primary);
+    }
+
+    .mdc-text-field:not(.mdc-text-field--disabled) .mdc-floating-label {
+        color: var(--ct-text-secondary);
+    }
+
+    .mdc-text-field:not(.mdc-text-field--disabled) .mdc-line-ripple::before {
+        border-bottom-color: var(--ct-border);
+    }
+
+    .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+        color: var(--ct-color-primary);
+    }
+
+    // Select
+    .mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text {
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-select:not(.mdc-select--disabled) .mdc-floating-label {
+        color: var(--ct-text-secondary);
+    }
+
+    .mdc-select__dropdown-icon {
+        background: none;
+    }
+
+    // Menus / select menu surface
+    .mdc-menu-surface {
+        background-color: var(--ct-surface);
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-menu-surface .mdc-list-item {
+        color: var(--ct-on-surface);
+    }
+
+    // Snackbars (toast notifications)
+    .mdc-snackbar__surface {
+        background-color: #e6e6e6;
+        color: #121212;
+    }
+
+    .mdc-snackbar__label {
+        color: #121212;
+    }
+
+    .mdc-snackbar__action {
+        color: var(--ct-color-primary);
+    }
+
+    .mdc-snackbar__dismiss {
+        color: rgba(18, 18, 18, 0.7);
+    }
+
+    // Chips
+    .mdc-chip {
+        background-color: rgba(255, 255, 255, 0.08);
+        color: var(--ct-on-surface);
+    }
+
+    // Buttons
+    .mdc-button:not(:disabled) {
+        color: var(--ct-color-primary);
+    }
+
+    .mdc-button--raised:not(:disabled),
+    .mdc-button--unelevated:not(:disabled) {
+        background-color: var(--ct-color-primary);
+        color: var(--ct-on-primary);
+    }
+
+    // Disabled states
+    .mdc-button:disabled {
+        color: var(--ct-disabled-on);
+    }
+
+    // Focus states — keep a visible, themed focus ring on interactive chrome.
+    .mdc-icon-button:focus-visible,
+    .mdc-button:focus-visible,
+    .mdc-list-item:focus-visible,
+    .link:focus-visible {
+        outline: 2px solid var(--ct-focus-ring);
+        outline-offset: 2px;
+    }
+}

--- a/src/ChessTrainerApp/app/_dark-theme.scss
+++ b/src/ChessTrainerApp/app/_dark-theme.scss
@@ -177,4 +177,14 @@
         outline: 2px solid var(--ct-focus-ring);
         outline-offset: 2px;
     }
+
+    // Black pieces are solid-black artwork. On the board they sit on the
+    // (still light) board squares, but the captured-piece tray and the puzzle
+    // info card are dark surfaces in dark mode, so the black pieces would
+    // disappear. Add a light halo to keep them legible without inverting them
+    // (which would erase the white/black distinction).
+    .capturedPieces .piece--black,
+    .mdc-card .piece--black {
+        filter: drop-shadow(0 0 1px var(--ct-piece-outline)) drop-shadow(0 0 1.5px var(--ct-piece-outline));
+    }
 }

--- a/src/ChessTrainerApp/app/_dark-theme.scss
+++ b/src/ChessTrainerApp/app/_dark-theme.scss
@@ -9,8 +9,7 @@
     background-color: var(--ct-background);
     color: var(--ct-on-background);
 
-    body,
-    html {
+    body {
         background-color: var(--ct-background);
         color: var(--ct-on-background);
     }
@@ -131,12 +130,12 @@
 
     // Snackbars (toast notifications)
     .mdc-snackbar__surface {
-        background-color: #e6e6e6;
-        color: #121212;
+        background-color: var(--ct-snackbar-surface);
+        color: var(--ct-snackbar-on);
     }
 
     .mdc-snackbar__label {
-        color: #121212;
+        color: var(--ct-snackbar-on);
     }
 
     .mdc-snackbar__action {
@@ -144,7 +143,7 @@
     }
 
     .mdc-snackbar__dismiss {
-        color: rgba(18, 18, 18, 0.7);
+        color: var(--ct-snackbar-on-muted);
     }
 
     // Chips

--- a/src/ChessTrainerApp/app/_tokens.scss
+++ b/src/ChessTrainerApp/app/_tokens.scss
@@ -107,4 +107,10 @@
     // States
     --ct-focus-ring: var(--ct-color-primary);
     --ct-disabled-on: rgba(255, 255, 255, 0.38);
+
+    // Snackbar — intentionally inverted (light surface, dark text) per Material,
+    // even in dark mode.
+    --ct-snackbar-surface: #e6e6e6;
+    --ct-snackbar-on: #121212;
+    --ct-snackbar-on-muted: rgba(18, 18, 18, 0.7);
 }

--- a/src/ChessTrainerApp/app/_tokens.scss
+++ b/src/ChessTrainerApp/app/_tokens.scss
@@ -1,0 +1,105 @@
+// Theme tokens — single source of truth for the visual language.
+//
+// Colors, spacing, and typography are exposed as CSS custom properties so the
+// app can switch between light and dark at runtime by toggling the
+// `data-theme` attribute on <html> (see app.js / _Host.cshtml). The light
+// values here mirror the compile-time `$mdc-theme-*` Sass variables in
+// _variables.scss; keep the two in sync when changing the light palette.
+
+:root {
+    // Brand
+    --ct-color-primary: #2e7d32; // Green 800
+    --ct-on-primary: #ffffff;
+    --ct-color-secondary: #424242; // Grey 800
+    --ct-on-secondary: #ffffff;
+
+    // Surfaces / background
+    --ct-surface: #fdfefb;
+    --ct-on-surface: #000000;
+    --ct-background: #fafafa;
+    --ct-on-background: #000000;
+    --ct-text-secondary: #424242; // Grey 800
+    --ct-border: rgba(0, 0, 0, 0.12);
+
+    // Chrome
+    --ct-app-bar-bg: var(--ct-color-primary);
+    --ct-app-bar-on: var(--ct-on-primary);
+    --ct-drawer-bg: #ffffff;
+    --ct-drawer-on: rgba(0, 0, 0, 0.87);
+
+    // Status
+    --ct-success: #2e7d32; // Green 800
+    --ct-error: #b00020;
+    --ct-correct: #2e7d32;
+    --ct-incorrect: #8b0000; // darkred
+
+    // Form validation
+    --ct-valid-outline: #26b050;
+    --ct-invalid-outline: #d32f2f;
+
+    // Board / decorators
+    --ct-spinner-track: #d3d3d3;
+    --ct-spinner-accent: var(--ct-color-primary);
+    // Filter applied to the board <img> (SVG internals aren't CSS-addressable);
+    // identity in light mode.
+    --ct-board-filter: none;
+
+    // States
+    --ct-focus-ring: var(--ct-color-primary);
+    --ct-disabled-on: rgba(0, 0, 0, 0.38);
+
+    // Spacing scale
+    --ct-space-1: 4px;
+    --ct-space-2: 8px;
+    --ct-space-3: 12px;
+    --ct-space-4: 16px;
+    --ct-space-5: 24px;
+    --ct-space-6: 32px;
+
+    // Typography
+    --ct-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+
+    // Brand — lighten the green so it keeps contrast on dark surfaces.
+    --ct-color-primary: #66bb6a; // Green 400
+    --ct-on-primary: #06210a;
+    --ct-color-secondary: #b0b0b0;
+    --ct-on-secondary: #000000;
+
+    // Surfaces / background
+    --ct-surface: #1e1e1e;
+    --ct-on-surface: #e6e6e6;
+    --ct-background: #121212;
+    --ct-on-background: #e6e6e6;
+    --ct-text-secondary: #b0b0b0;
+    --ct-border: rgba(255, 255, 255, 0.18);
+
+    // Chrome — use a dark surface for the app bar rather than the brand green.
+    --ct-app-bar-bg: #272727;
+    --ct-app-bar-on: #e6e6e6;
+    --ct-drawer-bg: #1e1e1e;
+    --ct-drawer-on: rgba(255, 255, 255, 0.87);
+
+    // Status
+    --ct-success: #66bb6a;
+    --ct-error: #cf6679;
+    --ct-correct: #66bb6a;
+    --ct-incorrect: #ef5350;
+
+    // Form validation
+    --ct-valid-outline: #66bb6a;
+    --ct-invalid-outline: #cf6679;
+
+    // Board / decorators
+    --ct-spinner-track: #3a3a3a;
+    --ct-spinner-accent: var(--ct-color-primary);
+    // Soften the bright white board squares so they don't glare in dark mode.
+    --ct-board-filter: brightness(0.82) saturate(0.9);
+
+    // States
+    --ct-focus-ring: var(--ct-color-primary);
+    --ct-disabled-on: rgba(255, 255, 255, 0.38);
+}

--- a/src/ChessTrainerApp/app/_tokens.scss
+++ b/src/ChessTrainerApp/app/_tokens.scss
@@ -43,6 +43,9 @@
     // Filter applied to the board <img> (SVG internals aren't CSS-addressable);
     // identity in light mode.
     --ct-board-filter: none;
+    // Halo color used to keep solid-black pieces legible on dark surfaces;
+    // transparent (i.e. no halo) in light mode.
+    --ct-piece-outline: transparent;
 
     // States
     --ct-focus-ring: var(--ct-color-primary);
@@ -98,6 +101,8 @@
     --ct-spinner-accent: var(--ct-color-primary);
     // Soften the bright white board squares so they don't glare in dark mode.
     --ct-board-filter: brightness(0.82) saturate(0.9);
+    // Light halo so the solid-black piece artwork stays visible on dark surfaces.
+    --ct-piece-outline: rgba(255, 255, 255, 0.92);
 
     // States
     --ct-focus-ring: var(--ct-color-primary);

--- a/src/ChessTrainerApp/app/_variables.scss
+++ b/src/ChessTrainerApp/app/_variables.scss
@@ -1,4 +1,8 @@
-﻿$mdc-theme-primary: #2e7d32; // Green 800
+﻿// MDC Web 4.0 compiles these theme colors statically. They mirror the light
+// values of the runtime CSS variables in _tokens.scss — keep the two in sync
+// when changing the light palette. Dark mode is handled at runtime via the
+// --ct-* tokens and _dark-theme.scss, not here.
+$mdc-theme-primary: #2e7d32; // Green 800
 $mdc-theme-on-primary: #ffffff;
 $mdc-theme-secondary: #424242; // Grey 800
 $mdc-theme-on-secondary: #ffffff;

--- a/src/ChessTrainerApp/app/app.js
+++ b/src/ChessTrainerApp/app/app.js
@@ -122,3 +122,28 @@ window.getSelectValue = (selectElement) => {
     var selected = selectElement.querySelector('.mdc-list-item--selected');
     return (selected ? selected.getAttribute('data-value') : null);
 };
+
+// Theme handling — light/dark switch persisted in localStorage. The initial
+// theme is applied by a small inline script in _Host.cshtml before the page
+// renders (to avoid a flash of the wrong theme); these helpers let the Blazor
+// toggle read and update it at runtime.
+const THEME_STORAGE_KEY = 'ct-theme';
+
+window.getTheme = () => {
+    return document.documentElement.getAttribute('data-theme') || 'light';
+};
+
+window.setTheme = (theme) => {
+    const normalized = theme === 'dark' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', normalized);
+    try {
+        localStorage.setItem(THEME_STORAGE_KEY, normalized);
+    } catch (e) {
+        // Ignore storage failures (e.g. private mode); theme still applies for the session.
+    }
+    return normalized;
+};
+
+window.toggleTheme = () => {
+    return window.setTheme(window.getTheme() === 'dark' ? 'light' : 'dark');
+};

--- a/src/ChessTrainerApp/app/loadingSpinner.scss
+++ b/src/ChessTrainerApp/app/loadingSpinner.scss
@@ -16,9 +16,9 @@
     position: absolute;
     left: 50%;
     top: 50%;
-    border: 16px solid #d3d3d3; /* Light grey */
-    border-top: 16px solid #2e7d32; /* Green 800 */
-    border-bottom: 16px solid #2e7d32; /* Green 800 */
+    border: 16px solid var(--ct-spinner-track);
+    border-top: 16px solid var(--ct-spinner-accent);
+    border-bottom: 16px solid var(--ct-spinner-accent);
     border-radius: 50%;
     margin: -76px 0 0 -76px;
     width: 120px;

--- a/src/ChessTrainerApp/app/puzzleInfo.scss
+++ b/src/ChessTrainerApp/app/puzzleInfo.scss
@@ -24,11 +24,11 @@
 }
 
 .correctMessage {
-    color: green;
+    color: var(--ct-correct);
 }
 
 .incorrectMessage {
-    color: darkred;
+    color: var(--ct-incorrect);
 }
 
 .mdc-card .piece {

--- a/src/ChessTrainerApp/app/site.scss
+++ b/src/ChessTrainerApp/app/site.scss
@@ -1,4 +1,5 @@
 @import "./variables";
+@import "./tokens";
 @import "./loadingSpinner";
 @import "./puzzleInfo";
 @import "https://fonts.googleapis.com/icon?family=Material+Icons";
@@ -16,6 +17,7 @@
 @import "@material/layout-grid/mdc-layout-grid";
 @import "@material/snackbar/mdc-snackbar";
 @import "@material/typography/mdc-typography";
+@import "./dark-theme";
 
 /* Make sure the app bar shows over the menu drawer */
 .mdc-top-app-bar {
@@ -36,13 +38,13 @@
 }
 
 .mdc-typography--subtitle2 {
-    color: $mdc-theme-text-secondary-on-background;
+    color: var(--ct-text-secondary);
     margin-top: 0px;
 }
 
 .mdc-typography--subtitle2 svg {
     margin: 0px 0px 1px 3px;
-    color: $mdc-theme-text-secondary-on-background;
+    color: var(--ct-text-secondary);
 }
 
 .mdc-text-field .mdc-floating-label--float-above {
@@ -62,15 +64,15 @@
 }
 
 .mdc-card .mdc-list-item__text {
-    color: $mdc-list-item-primary-text-ink-color;
+    color: var(--ct-on-surface);
 }
 
 .mdc-card .mdc-list-item__secondary-text {
-    color: $mdc-list-item-secondary-text-ink-color;
+    color: var(--ct-text-secondary);
 }
 
 .mdc-card .mdc-icon-button {
-    color: $mdc-list-item-primary-text-ink-color;
+    color: var(--ct-on-surface);
 }
 
 .mdc-text-field--dense {
@@ -91,7 +93,7 @@
 }
 
 .mdc-top-app-bar__title a {
-    color: white;
+    color: var(--ct-app-bar-on);
     text-decoration: none;
 }
 
@@ -103,7 +105,7 @@
 
 .activePlayer h2 {
     font-weight: bold;
-    color: $mdc-theme-primary;
+    color: var(--ct-color-primary);
 }
 
 .selectable-list-item {
@@ -129,6 +131,8 @@
 body {
     height: 100vh;
     margin: 0;
+    background-color: var(--ct-background);
+    color: var(--ct-on-background);
 }
 
 body button {
@@ -136,19 +140,19 @@ body button {
 }
 
 html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: var(--ct-font-family);
 }
 
 .valid.modified:not([type=checkbox]) {
-    outline: 1px solid #26b050;
+    outline: 1px solid var(--ct-valid-outline);
 }
 
 .invalid {
-    outline: 1px solid red;
+    outline: 1px solid var(--ct-invalid-outline);
 }
 
 .validation-message {
-    color: red;
+    color: var(--ct-error);
 }
 
 /* Nested vertical grids can occupy the entire row of the parent grid */
@@ -173,6 +177,7 @@ html, body {
     width: 100%;
     height: auto;
     z-index: 0;
+    filter: var(--ct-board-filter);
 }
 
 .boardSquareDecorator {


### PR DESCRIPTION
## Why

ChessTrainer had no theming system: colors were hard-coded throughout the SCSS, and there was no dark mode. This adds a single source of truth for the visual language and a user-switchable dark theme, as requested in issue #30.

## Approach

The front end uses Material Components Web 4.0, whose theme colors are compiled statically and can't be re-themed at runtime by changing Sass variables. So the theme switch is driven entirely by toggling a `data-theme` attribute on `<html>`:

- **Token layer (`app/_tokens.scss`)** introduces CSS custom properties for colors, spacing, and typography in `:root`, with a dark palette overriding those tokens under `[data-theme="dark"]`. This is the single source of truth; the compile-time `$mdc-theme-*` Sass vars in `_variables.scss` now just mirror the light token values.
- **Dark skin (`app/_dark-theme.scss`)** restyles the MDC surfaces we actually use (app bar, drawer, cards, lists, text fields, selects, snackbars, buttons, chips) from the tokens when dark mode is active, including focus and disabled states, plus `color-scheme: dark` for native controls.
- **Hard-coded colors removed** from `site.scss`, `puzzleInfo.scss`, and `loadingSpinner.scss` in favor of tokens.
- **Header toggle** (`NavBar.razor`) flips the theme via JS interop; `app.js` exposes `getTheme`/`setTheme`/`toggleTheme` that persist the choice to `localStorage`. An inline script in `_Host.cshtml` applies the saved theme before first paint to avoid a flash of the wrong theme. Defaults to light and remembers the user's explicit choice.

## Things worth a careful look

- **Chessboard in dark mode.** `board.svg` is an `<img>`, so its internals aren't CSS-addressable. The board is softened with a CSS `filter` token (`brightness`/`saturate`) rather than swapping the asset.
- **Black piece legibility.** The solid-black piece artwork vanished on dark surfaces (the captured-piece tray and the puzzle info card). Pieces are now tagged `piece--white`/`piece--black`, and black pieces on those dark surfaces get a light halo (`drop-shadow`). Board pieces are left alone (the squares provide contrast), and pieces are not inverted so the white/black distinction is preserved.

## Verification

- `npm run webpack-prod` compiles with zero warnings.
- `dotnet build` Debug and Release (Release treats warnings as errors) both clean; app tests pass.
- Smoke-tested live: toggle switches and persists across reloads; nav, board, pieces, cards, text fields, and snackbars render correctly in both modes, including the previously-invisible captured black pieces.

## Screenshots

**Dark mode**

![Chess Trainer home in dark mode](https://github.com/user-attachments/assets/6298ffe2-1b6b-48af-b2f5-e2e96cbe8b4a)

**Light mode**

![Chess Trainer home in light mode](https://github.com/user-attachments/assets/af45fc46-d077-4699-9f3f-7ecf81aa8e6c)

**Captured black pieces in dark mode** - solid-black pieces get a light halo so they stay legible on dark surfaces (the captured-piece tray and puzzle info card).

![Captured black pieces with a light legibility halo in dark mode](https://github.com/user-attachments/assets/3571c8d0-d07f-4265-9652-409523e8999e)

Fixes: #30