### PR TITLE
Make multi-model code review the default in the code-review skill

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,13 +1,22 @@
 ---
 name: code-review
-description: Review code changes in ChessTrainer for correctness, performance, and consistency with project conventions. Use when reviewing PRs or code changes.
+description: Review code changes in ChessTrainer for correctness, performance, and consistency with project conventions. Use when reviewing PRs or code changes. Always launched as a parallel multi-model review (2-3 sub-agents with distinct model families) unless the environment cannot support it.
 ---
 
 # ChessTrainer Code Review
 
 Review code changes against the conventions, architecture, and gotchas documented in [`AGENTS.md`](../../../AGENTS.md). The "Code review checklist" section of that file is the source of truth for repo-specific review-blocking rules; this skill describes *how* to conduct the review.
 
+> **Before doing anything else:** If you are responding to a review request (e.g., `/review`, "please review PR #X", "look at this change") and you have the `task` tool with a `model` parameter, your *next action* is to enumerate available models, select 2-3 from distinct families per the rules in [Step 0: Orchestration](#step-0-orchestration--fan-out-first), and launch them in parallel. Do not perform the review yourself, do not delegate the whole review to a single sub-agent, and do not read further until those sub-agents are running.
+
 **Reviewer mindset:** Be polite but very skeptical. Your job is to help speed the review process for maintainers, which includes not only finding problems the PR author may have missed but also questioning the value of the PR in its entirety. Treat the PR description and linked issues as claims to verify, not facts to accept. Question the stated direction and probe edge cases.
+
+## Two Roles, Two Responsibilities
+
+This skill is executed by two distinct kinds of agents. Know which one you are before reading further.
+
+- **Orchestrator** — the agent that received the review request from the user (e.g., the CLI agent responding to `/review`). Your job is to launch N parallel reviewer sub-agents with **distinct models** and synthesize their outputs into one unified review. You do **not** perform the review yourself, and you do **not** delegate the whole review to a single sub-agent. Skip to [Step 0: Orchestration](#step-0-orchestration--fan-out-first).
+- **Reviewer sub-agent** — an agent invoked by the orchestrator via the `task` tool with `agent_type: code-review` and a specific `model`. Your job is to execute [Step 1: Gather Code Context](#step-1-gather-code-context-no-pr-narrative-yet) through [Step 5: Detailed Analysis](#step-5-detailed-analysis) on your assigned model and return findings to the orchestrator. Do **not** fan out further, and do **not** post comments to GitHub — the orchestrator handles synthesis and posting.
 
 ## When to Use This Skill
 
@@ -19,7 +28,45 @@ Use this skill when:
 
 ## Review Process
 
-### Step 0: Gather Code Context (No PR Narrative Yet)
+### Step 0: Orchestration — Fan Out First
+
+**This step is for the orchestrator only.** Reviewer sub-agents skip to Step 1.
+
+**Multi-model review is the default execution mode.** A review is incomplete unless ≥2 model families have reviewed independently. Skip the fan-out *only* if the `task` tool has no `model` parameter, if fewer than 2 eligible model families exist after applying the selection rules below, or if there is no `task` tool available — and in these cases, explicitly state the reason in the final output.
+
+**Model selection rules:**
+- Pick only from models explicitly listed as available in the environment. Do not guess or assume model names.
+- Select 2-3 models from distinct model families (e.g., one Claude, one GPT, one Gemini). If fewer than 2 eligible families are available, use what is available.
+- From each selected family, pick the highest-capability tier ("premium" or "standard" over "fast/cheap"). Never pick models labeled "mini", "fast", or "cheap".
+- Do not select the same model that is already running the primary/orchestrator session — the goal is diverse perspectives.
+- **Do not use `gpt-5.4`** (last verified 2026-06-12; revisit after 2026-09-12 — remove this exclusion if the gpt-5.4 sub-agent timeout issue has been resolved upstream) — known sub-agent timeout issues. Prefer `gpt-5.5` or `gpt-5.3-codex`; otherwise the highest-version non-blocked GPT model that satisfies the other rules.
+- If multiple standard-tier models exist in the same family (excluding blocked models), pick the highest version. Prefer `-codex` variants over general-purpose for code review.
+
+**Orchestrator pattern (do this, not a single delegation):**
+
+```
+# In ONE response, launch all sub-agents in parallel:
+parallel:
+  task(agent_type=code-review, model=<claude family>,  mode=background, prompt=<full review prompt>)
+  task(agent_type=code-review, model=<gpt family>,     mode=background, prompt=<full review prompt>)
+  task(agent_type=code-review, model=<gemini family>,  mode=background, prompt=<full review prompt>)
+
+# Then wait for completion notifications, read each with read_agent, and synthesize.
+```
+
+Give every sub-agent the **same prompt**: the PR number/diff, a pointer to this skill and [`AGENTS.md`](../../../AGENTS.md), instructions to produce findings in the severity format from [Review Output Format](#review-output-format), and an instruction **not to post comments to GitHub** — synthesis and posting are the orchestrator's job.
+
+**Synthesis:**
+1. Wait for all sub-agents. **Timeout handling:** if a sub-agent has not completed after 10 minutes and you have results from ≥2 others, proceed without it and note which model is missing.
+2. Deduplicate findings that appear across models.
+3. Elevate confidence on issues flagged by multiple models (mark with `✕N` where N is the count).
+4. Include unique findings from individual models that meet the confidence bar in the [Detailed Analysis](#step-5-detailed-analysis) rules.
+5. Produce one unified review in the [Review Output Format](#review-output-format). The `_Reviewed by: …_` line at the bottom is **mandatory** — see the output format section.
+6. After posting the review, immediately exit. Do not wait for any remaining sub-agents.
+
+**If no `task` tool is available or if the environment only has one eligible model**, perform the review yourself by executing Steps 1-5 below, and explicitly note the single-model limitation in the final output.
+
+### Step 1: Gather Code Context (No PR Narrative Yet)
 
 Before analyzing anything, collect as much relevant **code** context as you can. **Critically, do NOT read the PR description, linked issues, or existing review comments yet.** Form your own independent assessment of what the code does, why it might be needed, what problems it has, and whether the approach is sound — before being exposed to the author's framing. Reading the author's narrative first anchors your judgment and makes you less likely to find real problems.
 
@@ -31,7 +78,7 @@ Before analyzing anything, collect as much relevant **code** context as you can.
 6. **README files in the area.** Walk from the changed directory up to the repo root and read any `README.md` files you find (especially `src/IngestionFunctions/README.md` and `src/ChessTrainerApp/app/README.md`). They contain build/run/auth recipes that the diff may break.
 7. **Git history.** `git --no-pager log --oneline -20 -- <file>` on changed files reveals recent churn, reverts, or prior attempts to fix the same problem.
 
-### Step 1: Form an Independent Assessment
+### Step 2: Form an Independent Assessment
 
 Based **only** on the code context gathered above, answer:
 
@@ -42,7 +89,7 @@ Based **only** on the code context gathered above, answer:
 
 Write down your independent assessment before proceeding.
 
-### Step 2: Incorporate PR Narrative and Reconcile
+### Step 3: Incorporate PR Narrative and Reconcile
 
 Now read the PR description, labels, linked issues (in full), author information, and any existing review comments. Treat all of this as **claims to verify**, not facts to accept.
 
@@ -50,7 +97,7 @@ Now read the PR description, labels, linked issues (in full), author information
 2. Reconcile your assessment with the author's claims. Where your independent reading of the code disagrees with the PR description or issue, investigate further — but do not simply defer to the author's framing.
 3. Update your holistic assessment only if the additional context genuinely changes your evaluation (e.g., a linked issue proves the bug is real). Do not soften findings just because the PR description sounds reasonable.
 
-### Step 3: Apply the ChessTrainer Code Review Checklist
+### Step 4: Apply the ChessTrainer Code Review Checklist
 
 Walk the diff against every rule in the **Code review checklist** section of [`AGENTS.md`](../../../AGENTS.md). Today that means at minimum:
 
@@ -65,7 +112,7 @@ Also check the always-applicable items:
 
 - **Tests.** New behavior needs tests. Follow the conventions in [`.github/instructions/testing.instructions.md`](../../../.github/instructions/testing.instructions.md) (xUnit + bUnit, parallelization, env-var helpers, the migration regression guard). For data-layer changes, run `dotnet ef migrations has-pending-model-changes --project src\ChessTrainer.Data` mentally — if the entity changed but no migration was added, flag it.
 
-### Step 4: Detailed Analysis
+### Step 5: Detailed Analysis
 
 1. **Focus on what matters.** Prioritize bugs, performance regressions (especially N+1 EF queries, missing `AsNoTracking`, missing `OrderBy` before `Skip`/`Take`), safety issues, race conditions, resource leaks, and incorrect assumptions about Blazor Server's circuit/scoped DI lifetime. Do not comment on trivial style issues unless they violate an explicit rule.
 2. **Consider collateral damage.** For every changed code path, brainstorm: what other callers, scenarios, or inputs flow through this code? Could any of them break? Surface plausible risks even if you can't fully confirm them — the tradeoff is the author's decision; your job is to make it visible.
@@ -85,22 +132,6 @@ Also check the always-applicable items:
    - **Never assert that something "does not exist," "is deprecated," or "is unavailable" based on training data alone.** Your knowledge has a cutoff date. When uncertain, ask.
 9. **Ensure code suggestions are valid.** Any code you suggest must compile under the repo's analyzers (Nullable on, StyleCop, `TreatWarningsAsErrors` in Release).
 10. **Label in-scope vs. follow-up.** Distinguish between issues the PR should fix and out-of-scope improvements.
-
-## Multi-Model Review
-
-When the environment supports launching sub-agents with different models (e.g., the `task` tool with a `model` parameter), run the review in parallel across multiple model families to get diverse perspectives. Different models catch different classes of issues. If the environment does not support this, proceed with a single-model review.
-
-**How to execute (when supported):**
-1. Inspect the available model list and select models from 2-3 distinct model families, up to 3 sub-agent models total. If fewer than 2 eligible families are available, use what is available. **Model selection rules:**
-   - Pick only from models explicitly listed as available in the environment. Do not guess or assume model names.
-   - From each selected family, pick the model with the highest capability tier (prefer "premium" or "standard" over "fast/cheap").
-   - Never pick models labeled "mini", "fast", or "cheap" for code review.
-   - Do not select the same model that is already running the primary review. The goal is diverse perspectives from different model families.
-   - **Do not use `gpt-5.4`** (last verified 2026-06-12; revisit after 2026-09-12 — remove this exclusion if the gpt-5.4 sub-agent timeout issue has been resolved upstream) — it has known reliability issues causing sub-agent timeouts in the majority of affected runs. For the OpenAI/GPT family, prefer `gpt-5.5` or `gpt-5.3-codex` if they are explicitly listed as available; otherwise fall back to the highest-version non-blocked GPT model that satisfies the other rules.
-   - If multiple standard-tier models exist in the same family (excluding blocked models), pick the one with the highest version number. Prefer "-codex" variants over general-purpose for code review tasks.
-2. Launch a sub-agent for each selected model in parallel, giving each the same review prompt: the PR diff, the rules in this skill, [`AGENTS.md`](../../../AGENTS.md), and instructions to produce findings in the severity format above.
-3. Wait for all agents, then synthesize: deduplicate findings that appear across models, elevate issues flagged by multiple models (higher confidence), and include unique findings from individual models that meet the confidence bar. **Timeout handling:** If a sub-agent has not completed after 10 minutes and you have results from other agents, proceed with what you have.
-4. Present a single unified review, noting when an issue was flagged by multiple models. **After posting the review, immediately exit.** Do not wait for any remaining sub-agents.
 
 ## Repository-Specific Review Guidelines
 
@@ -173,9 +204,9 @@ When presenting the final review (whether as a PR comment or as output to the us
 ### Out of Scope / Follow-ups
 - <any improvements deliberately left for a later PR>
 
-<if multi-model review was used>
 _Reviewed by: <model A>, <model B>, <model C>. Issues marked ✕N were flagged by N models._
-</if>
 ```
+
+**The `_Reviewed by: …_` line is mandatory.** Every posted review must end with it, listing every model that contributed (including the orchestrator's synthesis model only if it added analysis beyond synthesis). If only one model is listed, the orchestrator skipped multi-model and the review is incomplete — re-run with the orchestrator pattern in [Step 0](#step-0-orchestration--fan-out-first). If multi-model was genuinely impossible (no `model` parameter, or <2 eligible families), say so explicitly on that line instead, e.g. `_Reviewed by: claude-opus-4.7 (single-model: only one eligible family available)._`
 
 If no issues were found, say so explicitly with ✅ LGTM and skip the empty sections.

--- a/src/ChessTrainerApp/Components/ChessPieceComponent.razor
+++ b/src/ChessTrainerApp/Components/ChessPieceComponent.razor
@@ -12,7 +12,7 @@
     [Parameter]
     public int Rank { get; set; }
 
-    public string Class => $"piece {ChessFormatter.FileToString(File)}{ChessFormatter.RankToString(Rank)}";
+    public string Class => $"piece piece--{(ChessFormatter.IsPieceWhite(PieceType) ? "white" : "black")} {ChessFormatter.FileToString(File)}{ChessFormatter.RankToString(Rank)}";
 
     string ImageSource => $"{SpriteSource}#{SvgView}";
 

--- a/src/ChessTrainerApp/Pages/_Host.cshtml
+++ b/src/ChessTrainerApp/Pages/_Host.cshtml
@@ -18,6 +18,18 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chess Trainer</title>
+    @* Apply the saved theme before any content renders to avoid a flash of the
+       wrong theme. Defaults to light when no preference has been stored. *@
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('ct-theme');
+                document.documentElement.setAttribute('data-theme', stored === 'dark' ? 'dark' : 'light');
+            } catch (e) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
     <link href="app.bundle.css" rel="stylesheet" />
     @if (javaScriptSnippet is not null)
     {

--- a/src/ChessTrainerApp/Shared/NavBar.razor
+++ b/src/ChessTrainerApp/Shared/NavBar.razor
@@ -12,6 +12,12 @@
         </section>
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" role="toolbar">
             @ChildContent
+            <button class="material-icons mdc-top-app-bar__action-item mdc-icon-button"
+                    aria-label="@ThemeToggleLabel"
+                    title="@ThemeToggleLabel"
+                    @onclick="ToggleTheme">
+                @ThemeToggleIcon
+            </button>
             <SignIn></SignIn>
         </section>
     </div>
@@ -38,6 +44,34 @@
 @code {
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
+
+    private bool isDarkTheme;
+
+    private string ThemeToggleIcon => isDarkTheme ? "light_mode" : "dark_mode";
+
+    private string ThemeToggleLabel => isDarkTheme ? "Switch to light theme" : "Switch to dark theme";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var theme = await JSRuntime.InvokeAsync<string>("getTheme");
+            var darkActive = theme == "dark";
+            if (darkActive != isDarkTheme)
+            {
+                isDarkTheme = darkActive;
+                StateHasChanged();
+            }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    async Task ToggleTheme()
+    {
+        var theme = await JSRuntime.InvokeAsync<string>("toggleTheme");
+        isDarkTheme = theme == "dark";
+    }
 
     async Task ToggleMainMenuDrawer()
     {

--- a/src/ChessTrainerApp/app/_dark-theme.scss
+++ b/src/ChessTrainerApp/app/_dark-theme.scss
@@ -1,0 +1,180 @@
+// Dark "skin" for Material Components Web.
+//
+// MDC 4.0 bakes its light theme colors into the compiled CSS, so we can't
+// re-theme it by changing Sass variables at runtime. Instead, when
+// `data-theme="dark"` is set on <html>, we restyle the MDC component surfaces
+// we actually use, pulling colors from the --ct-* tokens in _tokens.scss.
+
+[data-theme="dark"] {
+    background-color: var(--ct-background);
+    color: var(--ct-on-background);
+
+    body,
+    html {
+        background-color: var(--ct-background);
+        color: var(--ct-on-background);
+    }
+
+    // Top app bar
+    .mdc-top-app-bar {
+        background-color: var(--ct-app-bar-bg);
+        color: var(--ct-app-bar-on);
+    }
+
+    .mdc-top-app-bar__title a,
+    .mdc-top-app-bar__title.link {
+        color: var(--ct-app-bar-on);
+    }
+
+    .mdc-top-app-bar .mdc-icon-button,
+    .mdc-top-app-bar .mdc-button {
+        color: var(--ct-app-bar-on);
+    }
+
+    // Navigation drawer
+    .mdc-drawer {
+        background-color: var(--ct-drawer-bg);
+        border-color: var(--ct-border);
+        color: var(--ct-drawer-on);
+    }
+
+    .mdc-drawer .mdc-list-item {
+        color: var(--ct-drawer-on);
+    }
+
+    .mdc-drawer .mdc-list-item__graphic {
+        color: var(--ct-text-secondary);
+    }
+
+    .mdc-drawer .mdc-list-item--activated {
+        color: var(--ct-color-primary);
+    }
+
+    .mdc-drawer .mdc-list-item--activated .mdc-list-item__graphic {
+        color: var(--ct-color-primary);
+    }
+
+    // Cards
+    .mdc-card {
+        background-color: var(--ct-surface);
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-card .mdc-list-item__text,
+    .mdc-card .mdc-icon-button {
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-card .mdc-list-item__secondary-text {
+        color: var(--ct-text-secondary);
+    }
+
+    // Generic typography / text
+    .mdc-typography--subtitle2,
+    .mdc-typography--subtitle2 svg {
+        color: var(--ct-text-secondary);
+    }
+
+    // Lists
+    .mdc-list-item__primary-text {
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-list-item__secondary-text {
+        color: var(--ct-text-secondary);
+    }
+
+    // Text fields (filled + outlined)
+    .mdc-text-field {
+        background-color: rgba(255, 255, 255, 0.04);
+    }
+
+    .mdc-text-field:not(.mdc-text-field--disabled) .mdc-text-field__input {
+        color: var(--ct-on-surface);
+        caret-color: var(--ct-color-primary);
+    }
+
+    .mdc-text-field:not(.mdc-text-field--disabled) .mdc-floating-label {
+        color: var(--ct-text-secondary);
+    }
+
+    .mdc-text-field:not(.mdc-text-field--disabled) .mdc-line-ripple::before {
+        border-bottom-color: var(--ct-border);
+    }
+
+    .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+        color: var(--ct-color-primary);
+    }
+
+    // Select
+    .mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text {
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-select:not(.mdc-select--disabled) .mdc-floating-label {
+        color: var(--ct-text-secondary);
+    }
+
+    .mdc-select__dropdown-icon {
+        background: none;
+    }
+
+    // Menus / select menu surface
+    .mdc-menu-surface {
+        background-color: var(--ct-surface);
+        color: var(--ct-on-surface);
+    }
+
+    .mdc-menu-surface .mdc-list-item {
+        color: var(--ct-on-surface);
+    }
+
+    // Snackbars (toast notifications)
+    .mdc-snackbar__surface {
+        background-color: #e6e6e6;
+        color: #121212;
+    }
+
+    .mdc-snackbar__label {
+        color: #121212;
+    }
+
+    .mdc-snackbar__action {
+        color: var(--ct-color-primary);
+    }
+
+    .mdc-snackbar__dismiss {
+        color: rgba(18, 18, 18, 0.7);
+    }
+
+    // Chips
+    .mdc-chip {
+        background-color: rgba(255, 255, 255, 0.08);
+        color: var(--ct-on-surface);
+    }
+
+    // Buttons
+    .mdc-button:not(:disabled) {
+        color: var(--ct-color-primary);
+    }
+
+    .mdc-button--raised:not(:disabled),
+    .mdc-button--unelevated:not(:disabled) {
+        background-color: var(--ct-color-primary);
+        color: var(--ct-on-primary);
+    }
+
+    // Disabled states
+    .mdc-button:disabled {
+        color: var(--ct-disabled-on);
+    }
+
+    // Focus states — keep a visible, themed focus ring on interactive chrome.
+    .mdc-icon-button:focus-visible,
+    .mdc-button:focus-visible,
+    .mdc-list-item:focus-visible,
+    .link:focus-visible {
+        outline: 2px solid var(--ct-focus-ring);
+        outline-offset: 2px;
+    }
+}

--- a/src/ChessTrainerApp/app/_dark-theme.scss
+++ b/src/ChessTrainerApp/app/_dark-theme.scss
@@ -177,4 +177,14 @@
         outline: 2px solid var(--ct-focus-ring);
         outline-offset: 2px;
     }
+
+    // Black pieces are solid-black artwork. On the board they sit on the
+    // (still light) board squares, but the captured-piece tray and the puzzle
+    // info card are dark surfaces in dark mode, so the black pieces would
+    // disappear. Add a light halo to keep them legible without inverting them
+    // (which would erase the white/black distinction).
+    .capturedPieces .piece--black,
+    .mdc-card .piece--black {
+        filter: drop-shadow(0 0 1px var(--ct-piece-outline)) drop-shadow(0 0 1.5px var(--ct-piece-outline));
+    }
 }

--- a/src/ChessTrainerApp/app/_tokens.scss
+++ b/src/ChessTrainerApp/app/_tokens.scss
@@ -1,0 +1,105 @@
+// Theme tokens — single source of truth for the visual language.
+//
+// Colors, spacing, and typography are exposed as CSS custom properties so the
+// app can switch between light and dark at runtime by toggling the
+// `data-theme` attribute on <html> (see app.js / _Host.cshtml). The light
+// values here mirror the compile-time `$mdc-theme-*` Sass variables in
+// _variables.scss; keep the two in sync when changing the light palette.
+
+:root {
+    // Brand
+    --ct-color-primary: #2e7d32; // Green 800
+    --ct-on-primary: #ffffff;
+    --ct-color-secondary: #424242; // Grey 800
+    --ct-on-secondary: #ffffff;
+
+    // Surfaces / background
+    --ct-surface: #fdfefb;
+    --ct-on-surface: #000000;
+    --ct-background: #fafafa;
+    --ct-on-background: #000000;
+    --ct-text-secondary: #424242; // Grey 800
+    --ct-border: rgba(0, 0, 0, 0.12);
+
+    // Chrome
+    --ct-app-bar-bg: var(--ct-color-primary);
+    --ct-app-bar-on: var(--ct-on-primary);
+    --ct-drawer-bg: #ffffff;
+    --ct-drawer-on: rgba(0, 0, 0, 0.87);
+
+    // Status
+    --ct-success: #2e7d32; // Green 800
+    --ct-error: #b00020;
+    --ct-correct: #2e7d32;
+    --ct-incorrect: #8b0000; // darkred
+
+    // Form validation
+    --ct-valid-outline: #26b050;
+    --ct-invalid-outline: #d32f2f;
+
+    // Board / decorators
+    --ct-spinner-track: #d3d3d3;
+    --ct-spinner-accent: var(--ct-color-primary);
+    // Filter applied to the board <img> (SVG internals aren't CSS-addressable);
+    // identity in light mode.
+    --ct-board-filter: none;
+
+    // States
+    --ct-focus-ring: var(--ct-color-primary);
+    --ct-disabled-on: rgba(0, 0, 0, 0.38);
+
+    // Spacing scale
+    --ct-space-1: 4px;
+    --ct-space-2: 8px;
+    --ct-space-3: 12px;
+    --ct-space-4: 16px;
+    --ct-space-5: 24px;
+    --ct-space-6: 32px;
+
+    // Typography
+    --ct-font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+
+[data-theme="dark"] {
+    color-scheme: dark;
+
+    // Brand — lighten the green so it keeps contrast on dark surfaces.
+    --ct-color-primary: #66bb6a; // Green 400
+    --ct-on-primary: #06210a;
+    --ct-color-secondary: #b0b0b0;
+    --ct-on-secondary: #000000;
+
+    // Surfaces / background
+    --ct-surface: #1e1e1e;
+    --ct-on-surface: #e6e6e6;
+    --ct-background: #121212;
+    --ct-on-background: #e6e6e6;
+    --ct-text-secondary: #b0b0b0;
+    --ct-border: rgba(255, 255, 255, 0.18);
+
+    // Chrome — use a dark surface for the app bar rather than the brand green.
+    --ct-app-bar-bg: #272727;
+    --ct-app-bar-on: #e6e6e6;
+    --ct-drawer-bg: #1e1e1e;
+    --ct-drawer-on: rgba(255, 255, 255, 0.87);
+
+    // Status
+    --ct-success: #66bb6a;
+    --ct-error: #cf6679;
+    --ct-correct: #66bb6a;
+    --ct-incorrect: #ef5350;
+
+    // Form validation
+    --ct-valid-outline: #66bb6a;
+    --ct-invalid-outline: #cf6679;
+
+    // Board / decorators
+    --ct-spinner-track: #3a3a3a;
+    --ct-spinner-accent: var(--ct-color-primary);
+    // Soften the bright white board squares so they don't glare in dark mode.
+    --ct-board-filter: brightness(0.82) saturate(0.9);
+
+    // States
+    --ct-focus-ring: var(--ct-color-primary);
+    --ct-disabled-on: rgba(255, 255, 255, 0.38);
+}

--- a/src/ChessTrainerApp/app/_tokens.scss
+++ b/src/ChessTrainerApp/app/_tokens.scss
@@ -43,6 +43,9 @@
     // Filter applied to the board <img> (SVG internals aren't CSS-addressable);
     // identity in light mode.
     --ct-board-filter: none;
+    // Halo color used to keep solid-black pieces legible on dark surfaces;
+    // transparent (i.e. no halo) in light mode.
+    --ct-piece-outline: transparent;
 
     // States
     --ct-focus-ring: var(--ct-color-primary);
@@ -98,6 +101,8 @@
     --ct-spinner-accent: var(--ct-color-primary);
     // Soften the bright white board squares so they don't glare in dark mode.
     --ct-board-filter: brightness(0.82) saturate(0.9);
+    // Light halo so the solid-black piece artwork stays visible on dark surfaces.
+    --ct-piece-outline: rgba(255, 255, 255, 0.92);
 
     // States
     --ct-focus-ring: var(--ct-color-primary);

--- a/src/ChessTrainerApp/app/_variables.scss
+++ b/src/ChessTrainerApp/app/_variables.scss
@@ -1,4 +1,8 @@
-﻿$mdc-theme-primary: #2e7d32; // Green 800
+﻿// MDC Web 4.0 compiles these theme colors statically. They mirror the light
+// values of the runtime CSS variables in _tokens.scss — keep the two in sync
+// when changing the light palette. Dark mode is handled at runtime via the
+// --ct-* tokens and _dark-theme.scss, not here.
+$mdc-theme-primary: #2e7d32; // Green 800
 $mdc-theme-on-primary: #ffffff;
 $mdc-theme-secondary: #424242; // Grey 800
 $mdc-theme-on-secondary: #ffffff;

--- a/src/ChessTrainerApp/app/app.js
+++ b/src/ChessTrainerApp/app/app.js
@@ -122,3 +122,28 @@ window.getSelectValue = (selectElement) => {
     var selected = selectElement.querySelector('.mdc-list-item--selected');
     return (selected ? selected.getAttribute('data-value') : null);
 };
+
+// Theme handling — light/dark switch persisted in localStorage. The initial
+// theme is applied by a small inline script in _Host.cshtml before the page
+// renders (to avoid a flash of the wrong theme); these helpers let the Blazor
+// toggle read and update it at runtime.
+const THEME_STORAGE_KEY = 'ct-theme';
+
+window.getTheme = () => {
+    return document.documentElement.getAttribute('data-theme') || 'light';
+};
+
+window.setTheme = (theme) => {
+    const normalized = theme === 'dark' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', normalized);
+    try {
+        localStorage.setItem(THEME_STORAGE_KEY, normalized);
+    } catch (e) {
+        // Ignore storage failures (e.g. private mode); theme still applies for the session.
+    }
+    return normalized;
+};
+
+window.toggleTheme = () => {
+    return window.setTheme(window.getTheme() === 'dark' ? 'light' : 'dark');
+};

--- a/src/ChessTrainerApp/app/loadingSpinner.scss
+++ b/src/ChessTrainerApp/app/loadingSpinner.scss
@@ -16,9 +16,9 @@
     position: absolute;
     left: 50%;
     top: 50%;
-    border: 16px solid #d3d3d3; /* Light grey */
-    border-top: 16px solid #2e7d32; /* Green 800 */
-    border-bottom: 16px solid #2e7d32; /* Green 800 */
+    border: 16px solid var(--ct-spinner-track);
+    border-top: 16px solid var(--ct-spinner-accent);
+    border-bottom: 16px solid var(--ct-spinner-accent);
     border-radius: 50%;
     margin: -76px 0 0 -76px;
     width: 120px;

--- a/src/ChessTrainerApp/app/puzzleInfo.scss
+++ b/src/ChessTrainerApp/app/puzzleInfo.scss
@@ -24,11 +24,11 @@
 }
 
 .correctMessage {
-    color: green;
+    color: var(--ct-correct);
 }
 
 .incorrectMessage {
-    color: darkred;
+    color: var(--ct-incorrect);
 }
 
 .mdc-card .piece {

--- a/src/ChessTrainerApp/app/site.scss
+++ b/src/ChessTrainerApp/app/site.scss
@@ -1,4 +1,5 @@
 @import "./variables";
+@import "./tokens";
 @import "./loadingSpinner";
 @import "./puzzleInfo";
 @import "https://fonts.googleapis.com/icon?family=Material+Icons";
@@ -16,6 +17,7 @@
 @import "@material/layout-grid/mdc-layout-grid";
 @import "@material/snackbar/mdc-snackbar";
 @import "@material/typography/mdc-typography";
+@import "./dark-theme";
 
 /* Make sure the app bar shows over the menu drawer */
 .mdc-top-app-bar {
@@ -36,13 +38,13 @@
 }
 
 .mdc-typography--subtitle2 {
-    color: $mdc-theme-text-secondary-on-background;
+    color: var(--ct-text-secondary);
     margin-top: 0px;
 }
 
 .mdc-typography--subtitle2 svg {
     margin: 0px 0px 1px 3px;
-    color: $mdc-theme-text-secondary-on-background;
+    color: var(--ct-text-secondary);
 }
 
 .mdc-text-field .mdc-floating-label--float-above {
@@ -62,15 +64,15 @@
 }
 
 .mdc-card .mdc-list-item__text {
-    color: $mdc-list-item-primary-text-ink-color;
+    color: var(--ct-on-surface);
 }
 
 .mdc-card .mdc-list-item__secondary-text {
-    color: $mdc-list-item-secondary-text-ink-color;
+    color: var(--ct-text-secondary);
 }
 
 .mdc-card .mdc-icon-button {
-    color: $mdc-list-item-primary-text-ink-color;
+    color: var(--ct-on-surface);
 }
 
 .mdc-text-field--dense {
@@ -91,7 +93,7 @@
 }
 
 .mdc-top-app-bar__title a {
-    color: white;
+    color: var(--ct-app-bar-on);
     text-decoration: none;
 }
 
@@ -103,7 +105,7 @@
 
 .activePlayer h2 {
     font-weight: bold;
-    color: $mdc-theme-primary;
+    color: var(--ct-color-primary);
 }
 
 .selectable-list-item {
@@ -129,6 +131,8 @@
 body {
     height: 100vh;
     margin: 0;
+    background-color: var(--ct-background);
+    color: var(--ct-on-background);
 }
 
 body button {
@@ -136,19 +140,19 @@ body button {
 }
 
 html, body {
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-family: var(--ct-font-family);
 }
 
 .valid.modified:not([type=checkbox]) {
-    outline: 1px solid #26b050;
+    outline: 1px solid var(--ct-valid-outline);
 }
 
 .invalid {
-    outline: 1px solid red;
+    outline: 1px solid var(--ct-invalid-outline);
 }
 
 .validation-message {
-    color: red;
+    color: var(--ct-error);
 }
 
 /* Nested vertical grids can occupy the entire row of the parent grid */
@@ -173,6 +177,7 @@ html, body {
     width: 100%;
     height: auto;
     z-index: 0;
+    filter: var(--ct-board-filter);
 }
 
 .boardSquareDecorator {


### PR DESCRIPTION
## Summary

Restructure `.agents/skills/code-review/SKILL.md` so that multi-model review actually happens by default. Motivated by a real failure during the PR #49 review where the orchestrator delegated to a single `code-review` sub-agent and skipped the multi-model fan-out entirely — the requirement was buried in the middle of the skill and read as an opt-in.

## Changes to `SKILL.md`

1. **Frontmatter `description`** now ends with *"Always launched as a parallel multi-model review (2-3 sub-agents with distinct model families) unless the environment cannot support it."* — surfaces the rule in the orchestrator's skills list without it having to open the file.
2. **Pre-flight callout at the very top** tells the orchestrator its next action *before* it reads the body.
3. **New "Two Roles, Two Responsibilities" section** disambiguates orchestrator vs. reviewer sub-agent and tells each which step to start from.
4. **Multi-model promoted to Step 0** (was buried at line 89). Old steps renumbered 0→1, 1→2, …, 4→5; all in-document anchors updated.
5. **Default-on language**: *"Multi-model review is the default execution mode. A review is incomplete unless ≥2 model families have reviewed independently."* Replaces the conditional *"When the environment supports…"*.
6. **Worked orchestrator pattern** as a code block (`parallel: task(...) task(...) task(...)`).
7. **`_Reviewed by: …_` line is now mandatory** in the output format. If only one model is listed, the review is incomplete and must be re-run. The single-model escape hatch is preserved — it must be stated explicitly on that line.

## Why these specific edits

Agents (myself included) tend to act on the first imperative they encounter and skim past optional-sounding sections. The fix raises the rule's visibility at three layers — the skills list (frontmatter), the document intro (pre-flight callout), and the very first step of the process — and adds an audit trail (the `_Reviewed by:_` line) so non-compliance is grep-able after the fact.

## Verification

- All step references updated; no orphan links to the old "Multi-Model Review" section.
- Internal anchors (`#step-0-orchestration--fan-out-first`, `#step-1-gather-code-context-no-pr-narrative-yet`, `#step-5-detailed-analysis`) all resolve to renumbered headings.

## Notes

This branch is stacked on `mjrousos/issue-30-dark-mode-theming` (PR #49). Once #49 merges, GitHub will retarget this PR's base to `main` automatically.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
