### PR TITLE
Add workflow_dispatch trigger to dotnet build workflow

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Why

The "dotnet build and test" workflow could only run automatically on `push` and `pull_request` to `main`. There was no way to kick it off on demand (for example, to re-validate `main` after an infrastructure change or to test a re-run). Issue #55 asks for a manual trigger.

## What

Adds a `workflow_dispatch:` entry to the `on:` section of `.github/workflows/dotnet-build.yml`. This surfaces the "Run workflow" button in the Actions UI and enables API-triggered runs, while leaving the existing `push` and `pull_request` triggers untouched.

Fixes: #55