### PR TITLE
Fix code-review eval workspace setup on Linux runners

### DIFF
--- a/.agents/evals/code-review-setup/dot-gitignore
+++ b/.agents/evals/code-review-setup/dot-gitignore
@@ -1,0 +1,7 @@
+# Stored under a non-dot filename in the repo (so it shows up in
+# ordinary directory listings) and copied into the trial workdir as
+# `.gitignore` by .agents/evals/code-review.eval.yaml. Its only job is
+# to keep the workspace-setup helper script (.vally-setup/setup.ps1)
+# out of the baseline `git add -A` commit so review stimuli don't see
+# it as a tracked repo file.
+.vally-setup/

--- a/.agents/evals/code-review-setup/setup.ps1
+++ b/.agents/evals/code-review-setup/setup.ps1
@@ -1,0 +1,49 @@
+#!/usr/bin/env pwsh
+#
+# Workspace setup helper for .agents/evals/code-review.eval.yaml.
+#
+# The eval YAML used to embed each of these steps as inline
+# `pwsh -NoProfile -Command "..."` commands, but on the Linux GitHub Actions
+# runner Vally executes each command via `/bin/sh -c`, and the inline pwsh
+# strings (especially the one with embedded `\"` backtick-escaped quotes)
+# tripped sh's quoting/command-substitution rules before pwsh was ever
+# invoked. Routing through `pwsh -NoProfile -File <path>` keeps the shell
+# command argument-free so /bin/sh has nothing to mis-parse, while all the
+# PowerShell-flavoured quoting stays inside this script.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Clean', 'AddBanner', 'EditAbout')]
+    [string] $Step
+)
+
+$ErrorActionPreference = 'Stop'
+
+switch ($Step) {
+    'Clean' {
+        # Scrub build artifacts and node_modules carried in from the local
+        # checkout so trials are deterministic and the workdir stays small.
+        Get-ChildItem -Path . -Include bin, obj, node_modules `
+            -Directory -Recurse -Force -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    'AddBanner' {
+        # Create the one new file committed on `feature/example-change` so
+        # `pre-pr-diff-against-main` (and any other stimulus reading
+        # `git diff main`) has a small, deterministic, plain-ASCII diff to
+        # review.
+        $bannerPath = 'src/ChessTrainerApp/app/example-banner.ts'
+        $bannerContents = @'
+export const exampleBanner = "Welcome to the puzzle solver!";
+'@
+        New-Item -Path $bannerPath -ItemType File -Force -Value $bannerContents | Out-Null
+    }
+    'EditAbout' {
+        # Leave one file with unstaged modifications so `git status` reports
+        # changes for `unstaged-changes-review`. We append a benign Razor
+        # comment so `git diff` shows real content and the file itself
+        # remains functional.
+        Add-Content -Path 'src/ChessTrainerApp/Pages/About.razor' `
+            -Value '@* TODO: extend with author bio and contact info *@'
+    }
+}

--- a/.agents/evals/code-review.eval.yaml
+++ b/.agents/evals/code-review.eval.yaml
@@ -55,10 +55,22 @@ environment:
       dest: src/
     - src: ../../test/
       dest: test/
+    # Workspace-setup helper script invoked by `commands:` below. Routed
+    # through `pwsh -NoProfile -File <path>` rather than inline
+    # `pwsh -NoProfile -Command "..."` because Vally executes each
+    # command via `/bin/sh -c` on the Linux runner, and sh mis-parses
+    # embedded pwsh-style escapes (backticks inside double quotes open
+    # legacy command substitution). Staged under `.vally-setup/` and
+    # paired with the `.gitignore` entry below so `git add -A` does not
+    # commit the helper into the baseline review repo.
+    - src: code-review-setup/setup.ps1
+      dest: .vally-setup/setup.ps1
+    - src: code-review-setup/dot-gitignore
+      dest: .gitignore
   commands:
     # Scrub build artifacts and node_modules carried in from the local
     # checkout so trials are deterministic and the workdir stays small.
-    - pwsh -NoProfile -Command "Get-ChildItem -Path . -Include bin,obj,node_modules -Directory -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue"
+    - pwsh -NoProfile -File .vally-setup/setup.ps1 -Step Clean
     # Initialize a minimal git repository so review stimuli that depend on
     # `git diff` / `git status` / `git diff main` have something to work
     # against. Without this the agents declined with "the working directory
@@ -76,17 +88,15 @@ environment:
     # and self-contained (a new file added) so review stimuli have an
     # unambiguous target.
     - git checkout -b feature/example-change --quiet
-    - pwsh -NoProfile -Command "New-Item -Path src/ChessTrainerApp/app/example-banner.ts -ItemType File -Force -Value 'export const exampleBanner = `\"Welcome to the puzzle solver!`\";' | Out-Null"
+    - pwsh -NoProfile -File .vally-setup/setup.ps1 -Step AddBanner
     - git add src/ChessTrainerApp/app/example-banner.ts
     - git commit --quiet -m "Add example banner module"
     # Leave one file with unstaged modifications so `git status` reports
-    # changes for `unstaged-changes-review`. We append a benign comment so
-    # `git diff` shows real content; the file itself remains functional.
-    # Wrapped in single-quoted YAML scalar because the inline content
-    # contains a `: ` (colon-space) sequence which would otherwise get
-    # parsed as a YAML mapping (Vally then fails with "child_process.exec
-    # received Object").
-    - 'pwsh -NoProfile -Command "Add-Content -Path src/ChessTrainerApp/Pages/About.razor -Value ''@* TODO: extend with author bio and contact info *@''"'
+    # changes for `unstaged-changes-review`. The actual edit lives in the
+    # `EditAbout` step of .vally-setup/setup.ps1 (see the AddBanner step
+    # for why we route file edits through a script rather than inline
+    # `pwsh -Command "..."`).
+    - pwsh -NoProfile -File .vally-setup/setup.ps1 -Step EditAbout
 
 scoring:
   # Weights mirror stockfish-cli and are chosen so each grader is binding at


### PR DESCRIPTION
## Problem

Every trial of the nightly Vally `code-review` eval was erroring out before the model was invoked:

```
Command failed: pwsh -NoProfile -Command "New-Item -Path src/ChessTrainerApp/app/example-banner.ts -ItemType File -Force -Value 'export const exampleBanner = `\"Welcome to the puzzle solver!`\";' | Out-Null"
/bin/sh: 1: Syntax error: Unterminated quoted string
```

Vally executes each `commands:` entry through `child_process.exec` -> `/bin/sh -c`. On the `ubuntu-latest` runner, sh treated the backtick (` `  ` `) inside the outer double quotes as legacy command substitution and tried to run the half-quoted `\"Welcome to the puzzle solver!` as an inner shell — which has an unterminated `"`. `pwsh` was never reached. The same string parses fine when PowerShell sees it directly (e.g. on Windows), which is presumably how it was authored.

Result in the latest nightly run (`vally-results-nightly-27949768192-1`): all 24 `code-review` trials errored at setup; `chess-visualizer`, `stockfish-cli`, `create-eval` were green; one `zero-warnings-build` trial timed out (unrelated, flaky single trial).

## Fix

Keep pwsh, but route the three pwsh setup steps through an external script invoked via:

`pwsh -NoProfile -File .vally-setup/setup.ps1 -Step <Clean|AddBanner|EditAbout>`

`/bin/sh` now only sees argument-free tokens, so there is nothing for it to mis-parse. All PowerShell-flavoured quoting stays inside the `.ps1` file; the banner content uses a here-string so it needs no escaping at all.

The helper is staged under `.vally-setup/` and paired with a `.gitignore` entry so the baseline `git add -A` in `commands:` does not capture it into the review repo the agent inspects.

## Validation

- `vally lint --eval-spec .agents/evals/code-review.eval.yaml` passes.
- Smoke-tested `setup.ps1` against a temp workdir: produced `example-banner.ts` and the appended `About.razor` line byte-for-byte identical to the original inline commands.
- Reviewed by GPT-5.5 and Gemini 3.1 Pro: both confirm the fix is correct; specifically that `pwsh -File` survives `/bin/sh -c`, that `.gitignore` reliably keeps the helper out of the baseline commit (file is still untracked when `git add -A` runs), and that the `Clean` step's `-Include bin,obj,node_modules` filter cannot touch `.vally-setup/`.

## Out of scope

The single flaky timeout in `zero-warnings-build / fix-specific-nullability-warning / trial-1`. Trial 0 of the same stimulus succeeded; will revisit only if it flakes again.
