### PR TITLE
Document Docker workflow and fix startup assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,34 @@ queue) to populate puzzles end-to-end.
 > migration to Microsoft Entra External ID is tracked in
 > [#39](https://github.com/mjrousos/ChessTrainer/issues/39).
 
+### Build and run the Docker image
+
+From the repository root, build the web app image with the Dockerfile in
+`src/ChessTrainerApp/`:
+
+```powershell
+docker build -t chesstrainerapp -f src/ChessTrainerApp/Dockerfile .
+```
+
+Then run the image locally:
+
+```powershell
+docker run --rm -d -p 8080:80 --name chesstrainerapp chesstrainerapp
+```
+
+Open <http://localhost:8080> to view the app. The container exposes port 80
+inside the image, so `-p 8080:80` maps it to your host machine. If you need
+an explicit database connection string, pass it at runtime with
+`ConnectionStrings__PuzzleDatabase`, for example:
+
+```powershell
+docker run --rm -d -p 8080:80 `
+  -e ConnectionStrings__PuzzleDatabase="Server=your-sql-server;Database=TacticsPuzzles;User Id=...;Password=..." `
+  --name chesstrainerapp chesstrainerapp
+```
+
+Stop and remove the container with `docker rm -f chesstrainerapp`.
+
 ### Run the ingestion functions (optional)
 
 Only needed if you want to populate puzzles end-to-end yourself. The

--- a/README.md
+++ b/README.md
@@ -176,16 +176,16 @@ docker build -t chesstrainerapp -f src/ChessTrainerApp/Dockerfile .
 Then run the image locally:
 
 ```powershell
-docker run --rm -d -p 8080:80 --name chesstrainerapp chesstrainerapp
+docker run --rm -d -p 8080:8080 --name chesstrainerapp chesstrainerapp
 ```
 
-Open <http://localhost:8080> to view the app. The container exposes port 80
-inside the image, so `-p 8080:80` maps it to your host machine. If you need
-an explicit database connection string, pass it at runtime with
-`ConnectionStrings__PuzzleDatabase`, for example:
+Open <http://localhost:8080> to view the app. The image is configured to run
+Kestrel on port 8080 inside the container, so `-p 8080:8080` maps it to your
+host machine. If you need an explicit database connection string, pass it at
+runtime with `ConnectionStrings__PuzzleDatabase`, for example:
 
 ```powershell
-docker run --rm -d -p 8080:80 `
+docker run --rm -d -p 8080:8080 `
   -e ConnectionStrings__PuzzleDatabase="Server=your-sql-server;Database=TacticsPuzzles;User Id=...;Password=..." `
   --name chesstrainerapp chesstrainerapp
 ```

--- a/src/ChessTrainerApp/Dockerfile
+++ b/src/ChessTrainerApp/Dockerfile
@@ -17,4 +17,4 @@ RUN dotnet publish "ChessTrainerApp.csproj" -c Release -o /app/publish
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "ChessTrainerApp.dll"]
+ENTRYPOINT ["dotnet", "MjrChess.Trainer.dll"]

--- a/src/ChessTrainerApp/Dockerfile
+++ b/src/ChessTrainerApp/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
-EXPOSE 80
+ENV ASPNETCORE_HTTP_PORTS=8080
+EXPOSE 8080
 EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build


### PR DESCRIPTION
## Summary
- Added README instructions for building and running the ChessTrainerApp Docker image locally, including a simple `docker build`/`docker run` flow and a connection-string override example.
- Fixed the container entrypoint so the app starts with the correct assembly name, `MjrChess.Trainer.dll`.

## Why
These changes make the local Docker workflow easier to discover and ensure the published image starts successfully with the correct executable.