### PR TITLE
Emit webpack output directly into wwwroot so containers serve _framework

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -144,7 +144,7 @@ Walk the diff against every rule in the **Code review checklist** section of [`A
 - **Connection strings have two names — update both.** `ConnectionStrings:PuzzleDatabase` (app) and `PuzzleDbConnectionString` env var (functions + `PuzzleDbContextFactory`).
 - **Don't depend on Azure AD B2C user-flow IDs.** The configured B2C tenant is dead (issue #39, migrating to Entra External ID).
 - **Application Insights is opt-in.** Only call `AddApplicationInsightsTelemetry()` when a connection string or instrumentation key is configured; use `GetService<TelemetryConfiguration>()`, never `GetRequiredService`.
-- **Respect the code style rules** (file-final newline, 4-space indent, `using` directives outside the namespace, no hand edits to `wwwroot/dist`).
+- **Respect the code style rules** (file-final newline, 4-space indent, `using` directives outside the namespace, no hand edits to anything under `wwwroot/`).
 
 Also check the always-applicable items:
 
@@ -186,7 +186,7 @@ This section captures review-time gotchas specific to ChessTrainer that go beyon
 - **Lifecycle.** `OnInitializedAsync` runs twice in prerendered Server mode; reserve interop and `HttpContext`-bound work for `OnAfterRenderAsync(firstRender)`.
 - **Threading.** State mutations from background threads (timers, `IObservable` callbacks, ingestion notifications) must go through `await InvokeAsync(StateHasChanged)`.
 - **Disposal.** Components that subscribe to engine events or hold `IDisposable` services must implement `IDisposable`/`IAsyncDisposable` and unsubscribe.
-- **Front-end assets.** Source goes in `src/ChessTrainerApp/app/` and is bundled by webpack into `wwwroot/dist/`. Reject hand edits to `wwwroot/dist` (they will be clobbered).
+- **Front-end assets.** Source goes in `src/ChessTrainerApp/app/` and is bundled by webpack directly into `wwwroot/` (which is fully generated and `.gitignore`d). Reject hand edits to anything under `wwwroot/` (they will be clobbered).
 
 ### Engine (`MjrChess.Engine`)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,4 +34,4 @@ Register `AddApplicationInsightsTelemetry()` **only** when `ApplicationInsights:
 - C# `latest`, `Nullable` enabled solution-wide (`Directory.Build.props`).
 - StyleCop.Analyzers is added by `Directory.Build.targets`; rules tuned in `rules.ruleset` and `stylecop.json`: 4-space indent; system `using` directives NOT required first; blank line between using groups; `using` directives outside the namespace; file must end with newline.
 - Razor: `@page` routes in `src/ChessTrainerApp/Pages/`; reusable components in `src/ChessTrainerApp/Components/` and `Shared/`.
-- Static web assets go under `src/ChessTrainerApp/app/` (webpack bundles them into `wwwroot/dist/`, which `Program.cs` serves via `UseWebRoot("wwwroot/dist")`). Don't hand-edit `wwwroot/dist`.
+- Static web assets go under `src/ChessTrainerApp/app/` (webpack bundles them directly into `wwwroot/`, alongside the Blazor framework assets the SDK materializes there). `wwwroot/` is fully generated and `.gitignore`d — don't hand-edit anything under it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Register `AddApplicationInsightsTelemetry()` **only** when `ApplicationInsights:
 - C# `latest`, `Nullable` enabled solution-wide (`Directory.Build.props`).
 - StyleCop.Analyzers is added by `Directory.Build.targets`; rules tuned in `rules.ruleset` and `stylecop.json`: 4-space indent; system `using` directives NOT required first; blank line between using groups; `using` directives outside the namespace; file must end with newline.
 - Razor: `@page` routes in `src/ChessTrainerApp/Pages/`; reusable components in `src/ChessTrainerApp/Components/` and `Shared/`.
-- Static web assets go under `src/ChessTrainerApp/app/` (webpack bundles them into `wwwroot/dist/`, which `Program.cs` serves via `UseWebRoot("wwwroot/dist")`). Don't hand-edit `wwwroot/dist`.
+- Static web assets go under `src/ChessTrainerApp/app/` (webpack bundles them directly into `wwwroot/`, alongside the Blazor framework assets the SDK materializes there). `wwwroot/` is fully generated and `.gitignore`d — don't hand-edit anything under it.
 
 ## PR feedback workflow
 
@@ -83,7 +83,7 @@ dotnet test  ChessTrainer.slnx -c Release
 dotnet run --project src/ChessTrainerApp
 
 # Front-end (auto-invoked by ChessTrainerApp's DebugRunWebpack target
-# when wwwroot/dist is missing — plain `dotnet build` is usually enough)
+# when the bundled outputs in wwwroot/ are missing — plain `dotnet build` is usually enough)
 cd src/ChessTrainerApp
 npm install
 npm run webpack-dev    # one-off dev build

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ git clone https://github.com/mjrousos/ChessTrainer.git
 cd ChessTrainer
 
 # Full build + tests. Webpack runs automatically via an MSBuild target the
-# first time wwwroot/dist is missing.
+# first time the bundled outputs in wwwroot/ are missing.
 dotnet build ChessTrainer.slnx -c Release
 dotnet test  ChessTrainer.slnx -c Release
 ```
@@ -209,10 +209,10 @@ Azure Storage account).
 ## Developer notes
 
 - **Front-end assets** live under `src/ChessTrainerApp/app/` (SCSS + JS,
-  built on Material Components Web) and are bundled by webpack into
-  `src/ChessTrainerApp/wwwroot/dist/`. `Program.cs` sets
-  `UseWebRoot("wwwroot/dist")`, so that's where the runtime serves static
-  files from — don't hand-edit `wwwroot/dist`.
+  built on Material Components Web) and are bundled by webpack directly
+  into `src/ChessTrainerApp/wwwroot/`, alongside the Blazor framework
+  assets the SDK materializes there at publish time. `wwwroot/` is fully
+  generated and `.gitignore`d — don't hand-edit anything under it.
 - **Models are duplicated by design.** `ChessTrainer.Data` exposes public
   domain models (`MjrChess.Trainer.Models.*` in `ChessTrainer.Common`)
   while keeping its EF entities (`MjrChess.Trainer.Data.Models.*`)

--- a/src/ChessTrainerApp/ChessTrainerApp.csproj
+++ b/src/ChessTrainerApp/ChessTrainerApp.csproj
@@ -31,7 +31,7 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
-  <Target Name="DebugRunWebpack" BeforeTargets="Build" Condition="!Exists('wwwroot\dist') ">
+  <Target Name="DebugRunWebpack" BeforeTargets="Build" Condition="!Exists('wwwroot\app.bundle.js') ">
     <!-- Ensure Node.js is installed -->
     <Exec Command="node --version" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
@@ -50,7 +50,7 @@
     <Exec Command="npm run webpack-prod" />
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>
-      <DistFiles Include="wwwroot\dist\**" />
+      <DistFiles Include="wwwroot\**" />
       <ResolvedFileToPublish Include="@(DistFiles->'%(FullPath)')" Exclude="@(ResolvedFileToPublish)">
         <RelativePath>%(DistFiles.Identity)</RelativePath>
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/src/ChessTrainerApp/Program.cs
+++ b/src/ChessTrainerApp/Program.cs
@@ -14,7 +14,6 @@ namespace MjrChess.Trainer
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseWebRoot("wwwroot/dist");
                     webBuilder.UseStartup<Startup>();
                 });
     }

--- a/src/ChessTrainerApp/webpack.config.js
+++ b/src/ChessTrainerApp/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const outDir = path.resolve(__dirname, 'wwwroot/dist');
+const outDir = path.resolve(__dirname, 'wwwroot');
 
 module.exports = [
     // 1. Styles bundle: app/site.scss -> app.bundle.css (+ static assets)


### PR DESCRIPTION
## Why

`blazor.server.js` returns 404 from the containerized app even though everything works under `dotnet run`. Without that file the Blazor circuit can't connect, so the app is effectively unusable in any published build.

## Root cause

`Program.cs` set `UseWebRoot("wwwroot/dist")` so webpack output (written to `wwwroot/dist/`) was reachable at the URL root. Under `dotnet run`, Blazor's framework assets at `/_framework/blazor.server.js` are still resolved by the Static Web Assets dev-time manifest, which layers a virtual file provider on top of `WebRootFileProvider` and points at files in the NuGet package cache — so the WebRoot override doesn't hurt.

In a published / containerized build there is no dev manifest. `dotnet publish` materializes the Blazor framework assets into `<publish>/wwwroot/_framework/`, but the runtime WebRoot is still `wwwroot/dist`, so `UseStaticFiles()` can't see `_framework/` and every request for it 404s.

## Fix

Point webpack at `wwwroot/` directly and drop the `UseWebRoot` override. Now the SDK-materialized `_framework/` and the webpack-generated `app.bundle.*` / `favicon.ico` / `images/` live side-by-side under one web root, which is exactly what `Microsoft.NET.Sdk.Web` expects.

- `webpack.config.js` - `outDir` is now `wwwroot`.
- `Program.cs` - removed `UseWebRoot("wwwroot/dist")`.
- `ChessTrainerApp.csproj` - `DebugRunWebpack` condition and `PublishRunWebpack`'s `DistFiles` glob now reference `wwwroot/` (the existence check uses `wwwroot/app.bundle.js` as the marker).
- Docs in `AGENTS.md`, `.github/copilot-instructions.md`, `README.md`, and `.agents/skills/code-review/SKILL.md` updated to match. `wwwroot/` is already in `.gitignore`, so no new entries.

## Verification

- `dotnet build ChessTrainer.slnx -c Release` - 0 warnings, 0 errors after wiping `wwwroot/`.
- `dotnet publish src/ChessTrainerApp -c Release` produces a publish tree containing both `wwwroot/_framework/blazor.server.js` and `wwwroot/app.bundle.js` (plus pre-compressed `.br` / `.gz` siblings).

## Reviewer notes

`wwwroot/` is now fully generated. The `code-review` skill and the copilot instructions were updated to reject hand edits to anything under `wwwroot/`, not just `wwwroot/dist`.