### PR TITLE
Lower CI eval-artifact retention to 7 days

### DIFF
--- a/.github/workflows/skill-eval-nightly.yml
+++ b/.github/workflows/skill-eval-nightly.yml
@@ -167,13 +167,13 @@ jobs:
           vally eval "${ARGS[@]}"
 
       - name: Upload eval results
-        # Always upload (even on failure) — nightly artifacts are kept longer
-        # (60 days) than PR artifacts (14 days) so you can do trend analysis
-        # across recent runs.
+        # Always upload (even on failure). Retained for 7 days to keep the
+        # account-wide Actions artifact-storage footprint low; raise
+        # retention-days if you need a longer nightly trend-history window.
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: vally-results-nightly-${{ github.run_id }}-${{ github.run_attempt }}
           path: vally-results/
-          retention-days: 60
+          retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/skill-eval-pr.yml
+++ b/.github/workflows/skill-eval-pr.yml
@@ -190,5 +190,5 @@ jobs:
         with:
           name: vally-results-${{ github.run_id }}-${{ github.run_attempt }}
           path: vally-results/
-          retention-days: 14
+          retention-days: 7
           if-no-files-found: warn


### PR DESCRIPTION
## Why

The account-wide GitHub Actions artifact storage quota was hit, which started failing the `Upload ...` artifact steps in CI across repos (it surfaced first on a SudokuBackend PR). The biggest contributor was this repo's nightly Vally eval: `skill-eval-nightly.yml` uploaded `vally-results-nightly-*` with `retention-days: 60`, so roughly 10 MB/night accumulated for two months.

## What

- `skill-eval-nightly.yml`: `retention-days` 60 -> 7, and refreshed the accompanying comment so it no longer advertises the old 60/14 day values.
- `skill-eval-pr.yml`: `retention-days` 14 -> 7 for consistency. This workflow is `workflow_dispatch`-only so it contributes little, but keeping eval artifacts uniformly short-lived avoids future creep.

Results are still uploaded on both success and failure; only the retention window changes. Raise `retention-days` again if you later want a longer trend-analysis or review window.

## Note

The existing older artifacts in this repo were already pruned separately (~107 MB reclaimed). This PR is the durable fix that stops them from re-accumulating.
